### PR TITLE
update sovi thresholds

### DIFF
--- a/social-vulnerability/sovi_thresholds_2021.csv
+++ b/social-vulnerability/sovi_thresholds_2021.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cac191bdd1dda722d6b459db81ece4ff5b36c75d9df965b1084f0ff5a94851f2
+size 2152


### PR DESCRIPTION
sovi thresholds table pulled from model-inputs repo that was missing and required for postgis.  