### PR TITLE
updated Sauid_km2, Sauid_ha in BldgExpRef_CA_master_v3p2

### DIFF
--- a/exposure/general-building-stock/BldgExpRef_CA_master_v3p2.csv
+++ b/exposure/general-building-stock/BldgExpRef_CA_master_v3p2.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8a1ac7556f3bbc1d03fd981ab9aafb913573c6d391a0e3b0fa07b907471701f
-size 871661827
+oid sha256:53fa50a7731dda7aa0e12cce562cdaf9f40b8a5cdb8f82b58c8643f7f8774d9a
+size 880611895


### PR DESCRIPTION
Updated the area (km2/ha) fields in BldgExpRef_CA_master_v3p2.csv to align with the previously updated areas in Geometry_SAUID which were not updated in the exposure source files https://github.com/OpenDRR/boundaries/commit/4181e416ab6c08a51a6b70ca8b9b20b24bc6c268

This PR address the issue 15
https://github.com/OpenDRR/openquake-inputs/issues/15