### PR TITLE
adjusted exposure files for Greater Vancouver

### DIFF
--- a/exposure/general-building-stock/expoDivide.py
+++ b/exposure/general-building-stock/expoDivide.py
@@ -294,7 +294,7 @@ for i, row in provs.iterrows():
                     del(selectFSAs)
                     if reg == 'Greater Vancouver':
                         #pick FSAs from my desired planning region
-                        selectFSAs = regdf['fsauid'][regdf['csdname'].isin(['West Vancouver', 'North Vancouver', 'Burrard Inlet 3', 'Burnaby', 'Vancouver', 'Greater Vancouver A', 'Musqueam 2', 'Richmond', 'Capilano 5', 'Seymour Creek 2', 'Mission 1', 'New Westminster', 'Port Moody', 'Anmore', 'Belcarra', 'Coquitlam', 'Coquitlam 2', 'Coquitlam 1', 'Port Coquitlam', 'Pitt Meadows', 'Katzie 1', 'Barnston Island 3', 'Langley 5', 'Whonnock 1', 'Maple Ridge'])].unique()
+                        selectFSAs = regdf['fsauid'][regdf['csdname'].isin(['West Vancouver', 'North Vancouver', 'Burrard Inlet 3', 'Burnaby', 'Vancouver', 'Greater Vancouver A', 'Musqueam 2', 'Capilano 5', 'Seymour Creek 2', 'Mission 1', 'Port Moody', 'Anmore', 'Belcarra', 'Coquitlam', 'Coquitlam 2', 'Coquitlam 1', 'Port Coquitlam', 'Pitt Meadows', 'Katzie 1', 'Barnston Island 3', 'Langley 5', 'Whonnock 1'])].unique()
                         selectFSAs = np.setdiff1d(selectFSAs,np.array(['V4N']))
                         #selectFSAs = checkPoly(selectFSAs, allFSAs, firstchar) #suspending here because these were chosen specifically
                         selectFSAs = [i for i in selectFSAs if i in allFSAs] #only allow FSA's to be used if they're still on the allFSAs list

--- a/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverNorth.csv
+++ b/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverNorth.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bef5f9fd40d3b0a3cc4d6d7feb7e529db48d5b492ff68890966f6887df41d06
-size 28914507
+oid sha256:507e8a3cdebb3a777ec7c2df94813826749f1fe2433bace87275db89b7ab04a3
+size 23513599

--- a/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverSouth.csv
+++ b/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverSouth.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b90ba5ea6a03205b703af840d1ddb24a51e3c44a2d4dd1390df5b01b0566fd9b
-size 12395909
+oid sha256:e3fc379f86ffff4b3864fe8df045f64cecca49f534a3579b48950ef9def074e6
+size 17796817


### PR DESCRIPTION
As requested!

I am hoping we can avoid creating a new area for this so our results are more generalizable. For this, I simply redistributed the relative amounts of exposure points between the 'north' and 'south' areas (which about 70K records compared to 30K records, respectively; its more even now). 

Let me know if this doesn't work.