### PR TITLE
further adjustment of GreaterVancouver exposure files

### DIFF
--- a/exposure/general-building-stock/expoDivide.py
+++ b/exposure/general-building-stock/expoDivide.py
@@ -294,7 +294,7 @@ for i, row in provs.iterrows():
                     del(selectFSAs)
                     if reg == 'Greater Vancouver':
                         #pick FSAs from my desired planning region
-                        selectFSAs = regdf['fsauid'][regdf['csdname'].isin(['West Vancouver', 'North Vancouver', 'Burrard Inlet 3', 'Burnaby', 'Vancouver', 'Greater Vancouver A', 'Musqueam 2', 'Capilano 5', 'Seymour Creek 2', 'Mission 1', 'Port Moody', 'Anmore', 'Belcarra', 'Coquitlam', 'Coquitlam 2', 'Coquitlam 1', 'Port Coquitlam', 'Pitt Meadows', 'Katzie 1', 'Barnston Island 3', 'Langley 5', 'Whonnock 1'])].unique()
+                        selectFSAs = regdf['fsauid'][regdf['csdname'].isin(['West Vancouver', 'North Vancouver', 'Burrard Inlet 3', 'Burnaby', 'Vancouver', 'Greater Vancouver A', 'Musqueam 2', 'Capilano 5', 'Seymour Creek 2', 'Mission 1'])].unique()
                         selectFSAs = np.setdiff1d(selectFSAs,np.array(['V4N']))
                         #selectFSAs = checkPoly(selectFSAs, allFSAs, firstchar) #suspending here because these were chosen specifically
                         selectFSAs = [i for i in selectFSAs if i in allFSAs] #only allow FSA's to be used if they're still on the allFSAs list

--- a/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverNorth.csv
+++ b/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverNorth.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:507e8a3cdebb3a777ec7c2df94813826749f1fe2433bace87275db89b7ab04a3
-size 23513599
+oid sha256:a57e67b6f1ab03f8bdec58c5474acccbbdc2889b3b2523466243493393ce6257
+size 19903844

--- a/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverSouth.csv
+++ b/exposure/general-building-stock/oqBldgExp_BC_V_GreaterVancouverSouth.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3fc379f86ffff4b3864fe8df045f64cecca49f534a3579b48950ef9def074e6
-size 17796817
+oid sha256:610de04858c42c611448d974577ecf4718f8873129c930cf6b93f0abe8953a7c
+size 21406572


### PR DESCRIPTION
One more tweek to minimize the difference in number of records in the 'north' and 'south' files. If this doesn't work, I'll make a more substantial adjustment to the script that will subdivide this portion of Vancouver into three parts.