### PR TITLE
Updated sovi source table (nov 2021)

### DIFF
--- a/social-vulnerability/sovi_sauid_nov2021.csv
+++ b/social-vulnerability/sovi_sauid_nov2021.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8695dfcefbfe408bc481ca5f99d1ce392a2a2ac12a917194608e896953c9e99e
+size 420044641


### PR DESCRIPTION
- updated from the provided sovi dauid nov 2021 source files
- the supplied sovi sauid nov 2021 is missing new SA 62000215
- updated the file with the new SA's, and applying values from DA into SA